### PR TITLE
It is possible to change multiply to xorps or blendps in some cases

### DIFF
--- a/public/klein/detail/entity.hpp
+++ b/public/klein/detail/entity.hpp
@@ -162,15 +162,15 @@ struct entity : public base_entity
 
         if constexpr ((PMask & 0b10) > 0)
         {
-            out.p1() = _mm_mul_ps(p1(), _mm_set_ps(-1.f, -1.f, -1.f, 1.f));
+            out.p1() = _mm_xor_ps(p1(), _mm_set_ps(-0.f, -0.f, -0.f, 0.f));
         }
         if constexpr ((PMask & 0b100) > 0)
         {
-            out.p2() = _mm_mul_ps(p2(), _mm_set_ps(-1.f, -1.f, -1.f, 1.f));
+            out.p2() = _mm_xor_ps(p2(), _mm_set_ps(-0.f, -0.f, -0.f, 0.f));
         }
         if constexpr ((PMask & 0b1000) > 0)
         {
-            out.p3() = _mm_mul_ps(p3(), _mm_set1_ps(-1.f));
+            out.p3() = _mm_xor_ps(p3(), _mm_set1_ps(-0.f));
         }
 
         return out;

--- a/public/klein/detail/exterior_product.hpp
+++ b/public/klein/detail/exterior_product.hpp
@@ -30,14 +30,14 @@ inline namespace detail
         p1_out = _mm_sub_ps(
             p1_out,
             _mm_mul_ps(KLN_SWIZZLE(a, 0, 2, 1, 3), KLN_SWIZZLE(b, 1, 0, 2, 3)));
-        p1_out = _mm_mul_ss(p1_out, _mm_set_ss(0.f));
+        p1_out = _mm_blend_ps(p1_out, _mm_setzero_ps(), 0b0001);
 
         p2_out
             = _mm_mul_ps(KLN_SWIZZLE(a, 3, 3, 3, 0), KLN_SWIZZLE(b, 0, 1, 2, 0));
         p2_out = _mm_sub_ps(
             p2_out,
             _mm_mul_ps(KLN_SWIZZLE(a, 0, 1, 2, 3), KLN_SWIZZLE(b, 3, 3, 3, 3)));
-        p2_out = _mm_mul_ss(p2_out, _mm_set_ss(0.f));
+        p2_out = _mm_blend_ps(p2_out, _mm_setzero_ps(), 0b0001);
     }
 
     // NOTE: p1 ^ p0 and p0 ^ p1 produce identical results
@@ -62,8 +62,8 @@ inline namespace detail
         p3_out
             = _mm_mul_ps(KLN_SWIZZLE(a, 3, 3, 3, 0), KLN_SWIZZLE(b, 3, 2, 1, 1));
 
-        p3_out = _mm_mul_ps(
-            _mm_set_ps(-1.f, -1.f, -1.f, 1.f),
+        p3_out = _mm_xor_ps(
+            _mm_set1_ps(-0.f),
             _mm_add_ss(
                 p3_out, _mm_dp_ps(a, KLN_SWIZZLE(b, 0, 3, 2, 1), 0b01100001)));
     }
@@ -82,7 +82,7 @@ inline namespace detail
         p3_out = _mm_sub_ps(
             p3_out,
             _mm_mul_ps(KLN_SWIZZLE(a, 0, 2, 1, 3), KLN_SWIZZLE(b, 2, 3, 1, 0)));
-        p3_out = _mm_mul_ss(p3_out, _mm_set_ss(0.f));
+        p3_out = _mm_blend_ps(p3_out, _mm_setzero_ps(), 0b0001);
     }
 
     // p0 ^ p3 = -p3 ^ p0
@@ -95,7 +95,7 @@ inline namespace detail
         p2_out = _mm_dp_ps(a, KLN_SWIZZLE(b, 0, 3, 2, 1), 0b11110001);
         if constexpr (Flip)
         {
-            p2_out = _mm_mul_ss(p2_out, _mm_set_ss(-1.f));
+            p2_out = _mm_xor_ps(p2_out, _mm_set_ps(0, 0, 0, -0.f));
         }
     }
 


### PR DESCRIPTION
Usage of mulps to negate can be replaced with xorps, which can execute
on more ports (SKL and newer), and has a lower latency.

Usage of mulss by zero to zero out just the lowest lane can be replaced
by blendps, which can execute on more ports (Haswell and newer) and has
a lower latency.

I couldn't get the benchmark project to work, otherwise I would have shown those results.. usually these changes help, but there is a slight danger in changing multiply-by-negative-1 to xor-by-negative-zero that it reduces opportunities for FMA-contraction. As far as I know, changing mulss to blendps should just be universally good.