### PR TITLE
Fix MSVC Warnings C4100/C4101

### DIFF
--- a/public/klein/detail/matrix.hpp
+++ b/public/klein/detail/matrix.hpp
@@ -22,8 +22,7 @@ namespace kln
 // Convert a motor to a column-major 4x4
 template <bool Translate = true>
 KLN_INLINE void KLN_VEC_CALL mat4x4_12(__m128 const& b,
-                                       [[maybe_unused]]
-                                       __m128 const* c,
+                                       [[maybe_unused]] __m128 const* c,
                                        __m128* out) noexcept
 {
     // The derivation of this conversion follows directly from the general

--- a/public/klein/detail/matrix.hpp
+++ b/public/klein/detail/matrix.hpp
@@ -22,6 +22,7 @@ namespace kln
 // Convert a motor to a column-major 4x4
 template <bool Translate = true>
 KLN_INLINE void KLN_VEC_CALL mat4x4_12(__m128 const& b,
+                                       [[maybe_unused]]
                                        __m128 const* c,
                                        __m128* out) noexcept
 {

--- a/public/klein/detail/sandwich.hpp
+++ b/public/klein/detail/sandwich.hpp
@@ -247,6 +247,7 @@ inline namespace detail
     template <bool Variadic = false, bool Translate = true>
     KLN_INLINE void KLN_VEC_CALL swMM(__m128 const* in,
                                       __m128 const& b,
+                                      [[maybe_unused]]
                                       __m128 const* c,
                                       __m128* out,
                                       size_t count = 0) noexcept
@@ -330,9 +331,11 @@ inline namespace detail
         tmp6 = _mm_mul_ps(tmp6, scale);
 
         // Translation
-        __m128 tmp7; // scaled by a and added to p2
-        __m128 tmp8; // scaled by (a0, a3, a1, a2) and added to p2
-        __m128 tmp9; // scaled by (a0, a2, a3, a1) and added to p2
+        [[maybe_unused]] __m128 tmp7; // scaled by a and added to p2
+        [[maybe_unused]] __m128 tmp8; // scaled by (a0, a3, a1, a2) and added to p2
+        [[maybe_unused]] __m128 tmp9; // scaled by (a0, a2, a3, a1) and added to p2
+
+
         if constexpr (Translate)
         {
             __m128 czero = KLN_SWIZZLE(*c, 0, 0, 0, 0);
@@ -408,6 +411,7 @@ inline namespace detail
     template <bool Variadic = false, bool Translate = true>
     KLN_INLINE void KLN_VEC_CALL sw012(__m128 const* a,
                                        __m128 const& b,
+                                       [[maybe_unused]]
                                        __m128 const* c,
                                        __m128* out,
                                        size_t count = 0)
@@ -477,7 +481,7 @@ inline namespace detail
         // 2a3(b0 c3 + b1 c2 + b3 c0 - b2 c1)
         // by decomposing into four vectors, factoring out the a components
 
-        __m128 tmp4;
+        [[maybe_unused]] __m128 tmp4;
         if constexpr (Translate)
         {
             tmp4 = _mm_mul_ps(KLN_SWIZZLE(b, 0, 0, 0, 0), *c);
@@ -535,6 +539,7 @@ inline namespace detail
     template <bool Variadic = false, bool Translate = true>
     KLN_INLINE void KLN_VEC_CALL sw312(__m128 const* a,
                                        __m128 const& b,
+                                       [[maybe_unused]]
                                        __m128 const* c,
                                        __m128* out,
                                        size_t count = 0) noexcept

--- a/public/klein/detail/sandwich.hpp
+++ b/public/klein/detail/sandwich.hpp
@@ -247,8 +247,7 @@ inline namespace detail
     template <bool Variadic = false, bool Translate = true>
     KLN_INLINE void KLN_VEC_CALL swMM(__m128 const* in,
                                       __m128 const& b,
-                                      [[maybe_unused]]
-                                      __m128 const* c,
+                                      [[maybe_unused]] __m128 const* c,
                                       __m128* out,
                                       size_t count = 0) noexcept
     {
@@ -332,9 +331,8 @@ inline namespace detail
 
         // Translation
         [[maybe_unused]] __m128 tmp7; // scaled by a and added to p2
-        [[maybe_unused]] __m128 tmp8; // scaled by (a0, a3, a1, a2) and added to p2
-        [[maybe_unused]] __m128 tmp9; // scaled by (a0, a2, a3, a1) and added to p2
-
+        [[maybe_unused]] __m128 tmp8; // scaled by (a0, a3, a1, a2), added to p2
+        [[maybe_unused]] __m128 tmp9; // scaled by (a0, a2, a3, a1), added to p2
 
         if constexpr (Translate)
         {
@@ -411,8 +409,7 @@ inline namespace detail
     template <bool Variadic = false, bool Translate = true>
     KLN_INLINE void KLN_VEC_CALL sw012(__m128 const* a,
                                        __m128 const& b,
-                                       [[maybe_unused]]
-                                       __m128 const* c,
+                                       [[maybe_unused]] __m128 const* c,
                                        __m128* out,
                                        size_t count = 0)
     {
@@ -539,8 +536,7 @@ inline namespace detail
     template <bool Variadic = false, bool Translate = true>
     KLN_INLINE void KLN_VEC_CALL sw312(__m128 const* a,
                                        __m128 const& b,
-                                       [[maybe_unused]]
-                                       __m128 const* c,
+                                       [[maybe_unused]] __m128 const* c,
                                        __m128* out,
                                        size_t count = 0) noexcept
     {


### PR DESCRIPTION
Due to 'if constexpr' MSVC complains about:
	C4100: unreferenced formal parameter
	C4101: unreferenced local variable

Uses [[maybe_unused]] (C++17)