### PR TITLE
Feature/cmake config package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(klein LANGUAGES C CXX)
+project(klein VERSION 2.3.0 LANGUAGES C CXX)
 
 # Detect if we are a standalone projection or if we're included transitively
 # and set the various option defaults accordingly. By default, tests and utilities

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,13 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     option(KLEIN_ENABLE_PERF "Enable downloading external libs for perf analysis" ON)
     option(KLEIN_ENABLE_TESTS "Enable compilation of Klein tests" ON)
     option(KLEIN_VALIDATE "Enable runtime validations" ON)
+    option(KLEIN_INSTALL "Create CMake config-file package during install step" ON)
 else()
     set(KLEIN_STANDALONE OFF)
     option(KLEIN_ENABLE_PERF "Enable downloading external libs for perf analysis" OFF)
     option(KLEIN_ENABLE_TESTS "Enable compilation of Klein tests" OFF)
     option(KLEIN_VALIDATE "Enable runtime validations" OFF)
+    option(KLEIN_INSTALL "Create CMake config-file package during install step" ON)
 endif()
 
 option(KLEIN_BUILD_SYM "Enable compilation of symbolic Klein utility" ON)
@@ -42,14 +44,22 @@ endif()
 # The default platform and instruction set is x86 SSE3
 add_library(klein INTERFACE)
 add_library(klein::klein ALIAS klein)
-target_include_directories(klein INTERFACE public ${simde_SOURCE_DIR}/simde)
+target_include_directories(klein INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/public>
+    $<BUILD_INTERFACE:${simde_SOURCE_DIR}/simde>
+    $<INSTALL_INTERFACE:include>
+)
 if(NOT MSVC)
     target_compile_options(klein INTERFACE -msse3)
 endif()
 
 add_library(klein_cxx11 INTERFACE)
 add_library(klein::klein_cxx11 ALIAS klein_cxx11)
-target_include_directories(klein_cxx11 INTERFACE public ${simde_SOURCE_DIR}/simde)
+target_include_directories(klein_cxx11 INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/public>
+    $<BUILD_INTERFACE:${simde_SOURCE_DIR}/simde>
+    $<INSTALL_INTERFACE:include>
+)
 target_compile_features(klein_cxx11 INTERFACE cxx_std_11)
 if(NOT MSVC)
     target_compile_options(klein_cxx11 INTERFACE -msse3)
@@ -57,7 +67,11 @@ endif()
 
 add_library(klein_sse42 INTERFACE)
 add_library(klein::klein_sse42 ALIAS klein_sse42)
-target_include_directories(klein_sse42 INTERFACE public ${simde_SOURCE_DIR}/simde)
+target_include_directories(klein_sse42 INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/public>
+    $<BUILD_INTERFACE:${simde_SOURCE_DIR}/simde>
+    $<INSTALL_INTERFACE:include>
+)
 target_compile_features(klein_sse42 INTERFACE cxx_std_17)
 # SSE4.1 has > 97% market penetration according to the Steam hardware survey
 # queried as of December 2019 while AVX2 is around 70%. Thus, we can assume
@@ -89,4 +103,46 @@ endif()
 if(KLEIN_BUILD_C_BINDINGS)
     # Support dropped for the time being
     # add_subdirectory(c_src)
+endif()
+
+if(KLEIN_INSTALL)
+
+    install(TARGETS klein klein_cxx11 klein_sse42 EXPORT klein_targets)
+
+    install(DIRECTORY public/klein TYPE INCLUDE)
+
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/klein/klein-config-version.cmake"
+        VERSION ${CMAKE_PROJECT_VERSION}
+        COMPATIBILITY AnyNewerVersion
+    )
+
+    export(EXPORT klein_targets
+        FILE "${CMAKE_CURRENT_BINARY_DIR}/klein/klein-targets.cmake"
+        NAMESPACE klein::
+    )
+
+    configure_file(cmake/klein-config.cmake
+        "${CMAKE_CURRENT_BINARY_DIR}/klein/klein-config.cmake"
+        COPYONLY
+    )
+
+    set(ConfigPackageLocation share/klein)
+    install(EXPORT klein_targets
+        FILE
+            klein-targets.cmake
+        NAMESPACE
+            klein::
+        DESTINATION
+            ${ConfigPackageLocation}
+    )
+    install(
+        FILES
+            cmake/klein-config.cmake
+            "${CMAKE_CURRENT_BINARY_DIR}/klein/klein-config-version.cmake"
+        DESTINATION
+            ${ConfigPackageLocation}
+    )
+
 endif()

--- a/cmake/klein-config.cmake
+++ b/cmake/klein-config.cmake
@@ -1,0 +1,11 @@
+include("${CMAKE_CURRENT_LIST_DIR}/klein-targets.cmake")
+
+find_path(
+    simde_headers
+    "x86/sse4.2.h"
+    PATH_SUFFIXES "simde"
+)
+
+target_include_directories(klein::klein INTERFACE ${simde_headers})
+target_include_directories(klein::klein_cxx11 INTERFACE ${simde_headers})
+target_include_directories(klein::klein_sse42 INTERFACE ${simde_headers})


### PR DESCRIPTION
Set CMake project version to 2.3.0 Setting the version of the project will enable creating a CMake package version file.

Add a new option `KLEIN_INSTALL`. When this option is enabled, then a CMake config-file package will be created during the install step. By default, this option is set to ON for standalone projects. Otherwise, the option is set of OFF.

The header files will be installed into `include/klein`. Therefore, the include directory of the exported targets should be `include` (i.e. `$<INSTALL_INTERFACE:include>`). To distinguish this from the include directories during a build we use the `BUILD_INTERFACE` generator expression (e.g. `$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/public>`).

if `KLEIN_INSTALL` is set to ON, then the targets are installed and the CMake config-file package is created. Other CMake projects can then search for the package using e.g. `find_package(Klein 2.3.0)`.

`klein-config.cmake` will be executed by other projects when using `find_package`. Since klein depends on the simde headers, the CMake file will try to find these headers and add them to klein targets include
directories.