### PR TITLE
Fix plane::normalize w/o SSE4_1

### DIFF
--- a/public/klein/plane.hpp
+++ b/public/klein/plane.hpp
@@ -68,7 +68,7 @@ public:
 #ifdef KLEIN_SSE_4_1
         inv_norm = _mm_blend_ps(inv_norm, _mm_set_ss(1.f), 1);
 #else
-        inv_norm = _mm_add_ps(inv_norm, _mm_set_ss(1.f));
+        inv_norm = _mm_move_ss(inv_norm, _mm_set_ss(1.f));
 #endif
         p0_ = _mm_mul_ps(inv_norm, p0_);
     }


### PR DESCRIPTION
Fixes #23 by using [_mm_move_ss](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#techs=SSE,SSE2,SSE3,SSSE3&text=_mm_move_ss&ig_expand=6430,508,153,4843,4843) instead of _mm_add_ps

The bug occurs when KLEIN_SSE_4_1 is not defined.